### PR TITLE
Wrap generate_binstubs in an if statement

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,4 +4,3 @@ default['brightbox-ruby']['install_dev_package'] = true
 default['brightbox-ruby']['rubygems_version'] = nil
 default['brightbox-ruby']['gems'] = ["bundler", "rake", "rubygems-bundler"]
 default['brightbox-ruby']['install_ruby_switch'] = node['platform_version'].to_i < 14
-default['brightbox-ruby']['generate_binstubs'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,3 +4,4 @@ default['brightbox-ruby']['install_dev_package'] = true
 default['brightbox-ruby']['rubygems_version'] = nil
 default['brightbox-ruby']['gems'] = ["bundler", "rake", "rubygems-bundler"]
 default['brightbox-ruby']['install_ruby_switch'] = node['platform_version'].to_i < 14
+default['brightbox-ruby']['generate_binstubs'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,7 +45,7 @@ node['brightbox-ruby']['gems'].each do |gem|
   end
 end
 
-if node['brightbox-ruby']['generate_binstubs']
+if node['brightbox-ruby']['gems'].include? 'rubygems-bundler'
   # Regenerate the binstups for rubygems-bundler.
   execute "gem regenerate_binstubs" do
     action :nothing

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,8 +45,10 @@ node['brightbox-ruby']['gems'].each do |gem|
   end
 end
 
-# Regenerate the binstups for rubygems-bundler.
-execute "gem regenerate_binstubs" do
-  action :nothing
-  subscribes :run, resources('gem_package[rubygems-bundler]')
+if node['brightbox-ruby']['generate_binstubs']
+  # Regenerate the binstups for rubygems-bundler.
+  execute "gem regenerate_binstubs" do
+    action :nothing
+    subscribes :run, resources('gem_package[rubygems-bundler]')
+  end
 end


### PR DESCRIPTION
Add a default node attribute ['brightbox-ruby']['generate_binstubs'] set to true

There are situations when node['brightbox-ruby']['gems'] will be empty or not include rubygems-bundler, in those cases attempting to generate binstubs for rubygems-bundler will throw an exception.
